### PR TITLE
BugFix - Set correct cookie expiration time when cookie accepted and …

### DIFF
--- a/app/controllers/cookie_alert/cookies_controller.rb
+++ b/app/controllers/cookie_alert/cookies_controller.rb
@@ -22,7 +22,7 @@ module CookieAlert
       elsif CookieAlert.config.cookie_type == 'fixed_duration'
  
         # Set a fixed duration cookie
-        cookies.permanent.signed[CookieAlert.config.cookie_name.to_sym] = { value: 'accepted', expires: CookieAlert.config.num_days_until_cookie_expires.days.from_now }
+        cookies.signed[CookieAlert.config.cookie_name.to_sym] = { value: 'accepted', expires: CookieAlert.config.num_days_until_cookie_expires.days.from_now }
  
       else
  


### PR DESCRIPTION
I detected a bug when cookie type is fixed_duration and the cookie is accepted, you are setting a permanent cookie for 20 years and not for the fixed_duration.
